### PR TITLE
add: 숫자 콤마, 유효기간, 날짜 함수 구현 [#1]

### DIFF
--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -1,0 +1,1 @@
+export const addComma = (num: number) => new Intl.NumberFormat().format(num);

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,22 @@
+export const expireDate = (create: number, expire: number) => {
+  const period = expire - create;
+  if (period < 0) return "만료됨";
+
+  const hour = Math.floor(period / 60 / 60);
+  if (hour >= 48) return `${Math.floor(hour / 24)}일`;
+
+  const min = Math.floor(period / 60 - hour * 60);
+  return `${hour}시간 ${min.toString().padStart(2, "0")}분`;
+};
+
+export const createDate = (create: number) => {
+  const date = new Date(create * 1000);
+
+  const time = date.toTimeString().slice(0, 5);
+  const standard = date.toTimeString().split("+")[1];
+
+  return (
+    `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일 ` +
+    `${time} +${standard.slice(0, 2)}:${standard.slice(2, 4)}`
+  );
+};

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,11 +1,13 @@
-export const expireDate = (create: number, expire: number) => {
-  const period = expire - create;
+export const expireDate = (expire: number) => {
+  const today = new Date().getTime();
+  const period = expire * 1000 - today;
+
   if (period < 0) return "만료됨";
 
-  const hour = Math.floor(period / 60 / 60);
+  const hour = Math.floor(period / 1000 / 60 / 60);
   if (hour >= 48) return `${Math.floor(hour / 24)}일`;
 
-  const min = Math.floor(period / 60 - hour * 60);
+  const min = Math.floor(period / 1000 / 60 - hour * 60);
   return `${hour}시간 ${min.toString().padStart(2, "0")}분`;
 };
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -13,10 +13,10 @@ export const createDate = (create: number) => {
   const date = new Date(create * 1000);
 
   const time = date.toTimeString().slice(0, 5);
-  const standard = date.toTimeString().split("+")[1];
+  const standard = date.toTimeString().split(" (")[0].slice(-5);
 
   return (
     `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일 ` +
-    `${time} +${standard.slice(0, 2)}:${standard.slice(2, 4)}`
+    `${time} ${standard.slice(0, 3)}:${standard.slice(3, 5)}`
   );
 };


### PR DESCRIPTION
## 타입

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Other

## 구현사항
* 숫자 콤마
```typescript
import { addComma } from "utils/convert";

console.log(addComma(1234567));
// 1,234,567
```
* 유효기간 계산
현재시간 : 22년 2월 24일 20시 32분
 
``` typescript
import { expireDate } from "utils/date";

const expire = 1642033365; // 1월 13일 09:22

console.log(expireDate(expire));
// 만료됨
```
```typescript
const expire = 1645923723; // 2월 27일 10:02

console.log(expireDate(expire));
// 2일
```
```typescript
const expire = 1645710045;  // 2월 24일 22:40

console.log(expireDate(expire));
// 2시간 08분
```

* 날짜 함수 구현
```typescript
import { createDate } from "utils/date";

const create = 1641860565;

console.log(createDate(create);
// 2022년 1월 11일 09:22 +09:00
```

## 체크리스트

- [x] Linked Issues에서 적절한 이슈 하나를 걸어두었습니다.
- [x] 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 기능이 제대로 실행되는지 확인 하였습니다.
- [x] npm start로 구현한 화면 혹은 기능을 확인할 수 있습니다.

## 특이 사항
